### PR TITLE
Forge feature, shinier experience, bug fixes

### DIFF
--- a/src/nmt/minecraft/QuestManager/Configuration/PluginConfiguration.java
+++ b/src/nmt/minecraft/QuestManager/Configuration/PluginConfiguration.java
@@ -69,6 +69,10 @@ public class PluginConfiguration {
 		return config.getStringList("quests");
 	}
 	
+	public List<String> getWorlds() {
+		return config.getStringList("questworlds");
+	}
+	
 	/**
 	 * Gets the stored quest path information -- where the quest configuration files are stored
 	 * @return
@@ -119,6 +123,11 @@ public class PluginConfiguration {
 		config.set("version", QuestManagerPlugin.version);
 		config.set("conservativemode", true);
 		config.set("verbosemenus", false);
+		
+		List<String> worlds = new ArrayList<String>();
+		worlds.add("QuestWorld");
+		worlds.add("TutorialWorld");
+		config.set("questworlds", worlds);
 		//ConfigurationSection managers = config.createSection("managers");
 		
 		List<String> questNames = new ArrayList<String>(1);

--- a/src/nmt/minecraft/QuestManager/Configuration/QuestConfiguration.java
+++ b/src/nmt/minecraft/QuestManager/Configuration/QuestConfiguration.java
@@ -97,6 +97,16 @@ public class QuestConfiguration {
 				(boolean) QuestConfigurationField.REPEATABLE.getDefault());
 	}
 	
+	@SuppressWarnings("unchecked")
+	public List<String> getRequiredQuests() {
+		if (!config.contains(QuestConfigurationField.PREREQS.getKey())) {
+			return (List<String>) QuestConfigurationField.PREREQS.getDefault();
+		}
+		
+		return config.getStringList(QuestConfigurationField.PREREQS.getKey());
+				
+	}
+	
 	public Collection<NPC> getAuxNPCs() {
 		
 		List<NPC> npcs = new LinkedList<NPC>();

--- a/src/nmt/minecraft/QuestManager/Configuration/QuestConfiguration.java
+++ b/src/nmt/minecraft/QuestManager/Configuration/QuestConfiguration.java
@@ -92,6 +92,11 @@ public class QuestConfiguration {
 				(boolean) QuestConfigurationField.SAVESTATE.getDefault());
 	}
 	
+	public boolean isRepeatable() {
+		return config.getBoolean(QuestConfigurationField.REPEATABLE.getKey(), 
+				(boolean) QuestConfigurationField.REPEATABLE.getDefault());
+	}
+	
 	public Collection<NPC> getAuxNPCs() {
 		
 		List<NPC> npcs = new LinkedList<NPC>();

--- a/src/nmt/minecraft/QuestManager/Configuration/QuestConfigurationField.java
+++ b/src/nmt/minecraft/QuestManager/Configuration/QuestConfigurationField.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
  * <li>DESCRIPTION | description | "No Description"</li>
  * <li>GOALS | goals | <i>Empty List</i></li>
  * <li>SAVESTATE | savestate | false</li>
+ * <li>REPEATABKE | repeatable | false </li>
  * <li>NPCS | npcs | <i>Empty List</i></li>
  * <li>START | start | <i>null</i> </li>
  * <li> END | end | same </li>
@@ -31,6 +32,7 @@ public enum QuestConfigurationField {
 	DESCRIPTION("description", "No Description"),
 	GOALS("goals", new LinkedList<Goal>()),
 	SAVESTATE("savestate", false),
+	REPEATABLE("repeatable", false),
 	NPCS("npcs", new LinkedList<Goal>()),
 	START("start", null),
 	END("end", "same"),

--- a/src/nmt/minecraft/QuestManager/Configuration/QuestConfigurationField.java
+++ b/src/nmt/minecraft/QuestManager/Configuration/QuestConfigurationField.java
@@ -15,9 +15,10 @@ import org.bukkit.inventory.ItemStack;
  * <li>DESCRIPTION | description | "No Description"</li>
  * <li>GOALS | goals | <i>Empty List</i></li>
  * <li>SAVESTATE | savestate | false</li>
- * <li>REPEATABKE | repeatable | false </li>
+ * <li>REPEATABLE | repeatable | false </li>
  * <li>NPCS | npcs | <i>Empty List</i></li>
  * <li>START | start | <i>null</i> </li>
+ * <li>PREREQS | requiredquests | <i>Empty List</i></li>
  * <li> END | end | same </li>
  * <li> FAME | fame | 100 </li>
  * <li> REWARDS | rewards | <i>Empty List</i> </li>
@@ -35,6 +36,7 @@ public enum QuestConfigurationField {
 	REPEATABLE("repeatable", false),
 	NPCS("npcs", new LinkedList<Goal>()),
 	START("start", null),
+	PREREQS("requiredquests", new LinkedList<String>()),
 	END("end", "same"),
 	FAME("fame", 100),
 	REWARDS("rewards", new LinkedList<ItemStack>());

--- a/src/nmt/minecraft/QuestManager/NPC/ForgeNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/ForgeNPC.java
@@ -1,0 +1,172 @@
+package nmt.minecraft.QuestManager.NPC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import nmt.minecraft.QuestManager.QuestManagerPlugin;
+import nmt.minecraft.QuestManager.Configuration.EquipmentConfiguration;
+import nmt.minecraft.QuestManager.Configuration.Utils.LocationState;
+import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.UI.ChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.BioptionChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.Action.ForgeAction;
+import nmt.minecraft.QuestManager.UI.Menu.Message.BioptionMessage;
+import nmt.minecraft.QuestManager.UI.Menu.Message.SimpleMessage;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+
+/**
+ * NPC which offers to and repairs a players equipment, for a fee
+ * @author Skyler
+ *
+ */
+public class ForgeNPC extends SimpleBioptionNPC {
+	
+	/**
+	 * Registers this class as configuration serializable with all defined 
+	 * {@link aliases aliases}
+	 */
+	public static void registerWithAliases() {
+		for (aliases alias : aliases.values()) {
+			ConfigurationSerialization.registerClass(ForgeNPC.class, alias.getAlias());
+		}
+	}
+	
+	/**
+	 * Registers this class as configuration serializable with only the default alias
+	 */
+	public static void registerWithoutAliases() {
+		ConfigurationSerialization.registerClass(ForgeNPC.class);
+	}
+	
+
+	private enum aliases {
+		FULL("nmt.minecraft.QuestManager.NPC.ForgeNPC"),
+		DEFAULT(ForgeNPC.class.getName()),
+		SHORT("ForgeNPC"),
+		INFORMAL("FNPC");
+		
+		private String alias;
+		
+		private aliases(String alias) {
+			this.alias = alias;
+		}
+		
+		public String getAlias() {
+			return alias;
+		}
+	}
+	
+	@Override
+	public Map<String, Object> serialize() {
+		Map<String, Object> map = new HashMap<String, Object>(4);
+		
+		map.put("name", name);
+		map.put("type", entity.getType());
+		map.put("cost", cost);
+		map.put("location", new LocationState(entity.getLocation()));
+		
+		EquipmentConfiguration econ;
+		
+		if (entity instanceof LivingEntity) {
+			econ = new EquipmentConfiguration(
+					((LivingEntity) entity).getEquipment()
+					);
+		} else {
+			econ = new EquipmentConfiguration();
+		}
+		
+		map.put("equipment", econ);
+		
+		map.put("message", chat);
+	
+		
+		return map;
+	}
+	
+	public static ForgeNPC valueOf(Map<String, Object> map) {
+		if (map == null || !map.containsKey("name") || !map.containsKey("type") 
+				 || !map.containsKey("location") || !map.containsKey("equipment")
+				  || !map.containsKey("message") || !map.containsKey("cost")) {
+			QuestManagerPlugin.questManagerPlugin.getLogger().warning("Invalid NPC info! "
+					+ (map.containsKey("name") ? ": " + map.get("name") : ""));
+			return null;
+		}
+		
+		ForgeNPC npc = new ForgeNPC();
+		
+		EquipmentConfiguration econ = new EquipmentConfiguration();
+		try {
+			YamlConfiguration tmp = new YamlConfiguration();
+			tmp.createSection("key",  (Map<?, ?>) map.get("equipment"));
+			econ.load(tmp.getConfigurationSection("key"));
+		} catch (InvalidConfigurationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		LocationState ls = (LocationState) map.get("location");
+		Location loc = ls.getLocation();
+		
+		EntityType type = EntityType.valueOf((String) map.get("type"));
+		
+		npc.name = (String) map.get("name");
+		
+		npc.cost = (int) map.get("cost");
+		
+		npc.entity = loc.getWorld().spawnEntity(loc, type);
+		npc.entity.setCustomName((String) map.get("name"));
+
+		if (npc.entity instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+			equipment.setHelmet(econ.getHead());
+			equipment.setChestplate(econ.getChest());
+			equipment.setLeggings(econ.getLegs());
+			equipment.setBoots(econ.getBoots());
+			equipment.setItemInHand(econ.getHeld());
+			
+		}
+		
+		npc.chat = (BioptionMessage) map.get("message");		
+		
+		//provide our npc's name, unless we don't have one!
+		if (npc.name != null && !npc.name.equals("")) {
+			FancyMessage label = new FancyMessage(npc.name);
+			npc.chat.setSourceLabel(label);			
+		}
+		
+		return npc;
+	}
+		
+	private int cost;
+		
+	@Override
+	protected void interact(Player player) {
+		
+		QuestPlayer qp = QuestManagerPlugin.questManagerPlugin.getPlayerManager()
+				.getPlayer(player.getUniqueId());
+		
+		FancyMessage msg = new FancyMessage("My services be cheap, but still appear ")
+		.then("to cost more than what you have!")
+		.color(ChatColor.DARK_RED);
+			
+		SimpleMessage message = new SimpleMessage(msg);
+		message.setSourceLabel(new FancyMessage(this.name));
+		
+		ChatMenu messageChat = new BioptionChatMenu(chat, 
+					new ForgeAction(cost, qp, message)
+		, null);			
+
+		messageChat.show(player);
+	}
+	
+}

--- a/src/nmt/minecraft/QuestManager/NPC/ForgeNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/ForgeNPC.java
@@ -71,15 +71,15 @@ public class ForgeNPC extends SimpleBioptionNPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
+		map.put("type", getEntity().getType());
 		map.put("cost", cost);
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();
@@ -123,11 +123,13 @@ public class ForgeNPC extends SimpleBioptionNPC {
 		
 		npc.cost = (int) map.get("cost");
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.entity.setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.getEntity().setCustomName((String) map.get("name"));
+
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());

--- a/src/nmt/minecraft/QuestManager/NPC/ForgeNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/ForgeNPC.java
@@ -66,6 +66,10 @@ public class ForgeNPC extends SimpleBioptionNPC {
 		}
 	}
 	
+	private ForgeNPC(Location startingLoc) {
+		super(startingLoc);
+	}
+	
 	@Override
 	public Map<String, Object> serialize() {
 		Map<String, Object> map = new HashMap<String, Object>(4);
@@ -102,7 +106,6 @@ public class ForgeNPC extends SimpleBioptionNPC {
 			return null;
 		}
 		
-		ForgeNPC npc = new ForgeNPC();
 		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
@@ -117,6 +120,7 @@ public class ForgeNPC extends SimpleBioptionNPC {
 		LocationState ls = (LocationState) map.get("location");
 		Location loc = ls.getLocation();
 		
+		ForgeNPC npc = new ForgeNPC(loc);
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
 		npc.name = (String) map.get("name");

--- a/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
@@ -66,7 +66,11 @@ public class InnNPC extends SimpleBioptionNPC {
 			return alias;
 		}
 	}
+
 	
+	private InnNPC(Location startingLoc) {
+		super(startingLoc);
+	}
 	@Override
 	public Map<String, Object> serialize() {
 		Map<String, Object> map = new HashMap<String, Object>(4);
@@ -103,7 +107,6 @@ public class InnNPC extends SimpleBioptionNPC {
 			return null;
 		}
 		
-		InnNPC npc = new InnNPC();
 		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
@@ -118,6 +121,7 @@ public class InnNPC extends SimpleBioptionNPC {
 		LocationState ls = (LocationState) map.get("location");
 		Location loc = ls.getLocation();
 		
+		InnNPC npc = new InnNPC(loc);
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
 		npc.name = (String) map.get("name");

--- a/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
@@ -72,15 +72,15 @@ public class InnNPC extends SimpleBioptionNPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
+		map.put("type", getEntity().getType());
 		map.put("cost", cost);
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();
@@ -124,11 +124,13 @@ public class InnNPC extends SimpleBioptionNPC {
 		
 		npc.cost = (int) map.get("cost");
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.entity.setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.getEntity().setCustomName((String) map.get("name"));
+
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());

--- a/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
@@ -1,0 +1,173 @@
+package nmt.minecraft.QuestManager.NPC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import nmt.minecraft.QuestManager.QuestManagerPlugin;
+import nmt.minecraft.QuestManager.Configuration.EquipmentConfiguration;
+import nmt.minecraft.QuestManager.Configuration.Utils.LocationState;
+import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.UI.ChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.BioptionChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.Action.InnAction;
+import nmt.minecraft.QuestManager.UI.Menu.Message.BioptionMessage;
+import nmt.minecraft.QuestManager.UI.Menu.Message.SimpleMessage;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+
+/**
+ * NPC that offers a safe night to players<br />
+ * Stores the amount to charge players?
+ * @author Skyler
+ *
+ */
+public class InnNPC extends SimpleBioptionNPC {
+	
+	/**
+	 * Registers this class as configuration serializable with all defined 
+	 * {@link aliases aliases}
+	 */
+	public static void registerWithAliases() {
+		for (aliases alias : aliases.values()) {
+			ConfigurationSerialization.registerClass(InnNPC.class, alias.getAlias());
+		}
+	}
+	
+	/**
+	 * Registers this class as configuration serializable with only the default alias
+	 */
+	public static void registerWithoutAliases() {
+		ConfigurationSerialization.registerClass(InnNPC.class);
+	}
+	
+
+	private enum aliases {
+		FULL("nmt.minecraft.QuestManager.NPC.InnNPC"),
+		DEFAULT(InnNPC.class.getName()),
+		SHORT("InnNPC"),
+		INFORMAL("INNNPC");
+		
+		private String alias;
+		
+		private aliases(String alias) {
+			this.alias = alias;
+		}
+		
+		public String getAlias() {
+			return alias;
+		}
+	}
+	
+	@Override
+	public Map<String, Object> serialize() {
+		Map<String, Object> map = new HashMap<String, Object>(4);
+		
+		map.put("name", name);
+		map.put("type", entity.getType());
+		map.put("cost", cost);
+		map.put("location", new LocationState(entity.getLocation()));
+		
+		EquipmentConfiguration econ;
+		
+		if (entity instanceof LivingEntity) {
+			econ = new EquipmentConfiguration(
+					((LivingEntity) entity).getEquipment()
+					);
+		} else {
+			econ = new EquipmentConfiguration();
+		}
+		
+		map.put("equipment", econ);
+		
+		map.put("message", chat);
+	
+		
+		return map;
+	}
+	
+	public static InnNPC valueOf(Map<String, Object> map) {
+		if (map == null || !map.containsKey("name") || !map.containsKey("type") 
+				 || !map.containsKey("location") || !map.containsKey("equipment")
+				  || !map.containsKey("message") || !map.containsKey("cost")) {
+			QuestManagerPlugin.questManagerPlugin.getLogger().warning("Invalid NPC info! "
+					+ (map.containsKey("name") ? ": " + map.get("name") : ""));
+			return null;
+		}
+		
+		InnNPC npc = new InnNPC();
+		
+		EquipmentConfiguration econ = new EquipmentConfiguration();
+		try {
+			YamlConfiguration tmp = new YamlConfiguration();
+			tmp.createSection("key",  (Map<?, ?>) map.get("equipment"));
+			econ.load(tmp.getConfigurationSection("key"));
+		} catch (InvalidConfigurationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		LocationState ls = (LocationState) map.get("location");
+		Location loc = ls.getLocation();
+		
+		EntityType type = EntityType.valueOf((String) map.get("type"));
+		
+		npc.name = (String) map.get("name");
+		
+		npc.cost = (int) map.get("cost");
+		
+		npc.entity = loc.getWorld().spawnEntity(loc, type);
+		npc.entity.setCustomName((String) map.get("name"));
+
+		if (npc.entity instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+			equipment.setHelmet(econ.getHead());
+			equipment.setChestplate(econ.getChest());
+			equipment.setLeggings(econ.getLegs());
+			equipment.setBoots(econ.getBoots());
+			equipment.setItemInHand(econ.getHeld());
+			
+		}
+		
+		npc.chat = (BioptionMessage) map.get("message");		
+		
+		//provide our npc's name, unless we don't have one!
+		if (npc.name != null && !npc.name.equals("")) {
+			FancyMessage label = new FancyMessage(npc.name);
+			npc.chat.setSourceLabel(label);			
+		}
+		
+		return npc;
+	}
+		
+	private int cost;
+		
+	@Override
+	protected void interact(Player player) {
+		
+		QuestPlayer qp = QuestManagerPlugin.questManagerPlugin.getPlayerManager()
+				.getPlayer(player.getUniqueId());
+		
+		FancyMessage msg = new FancyMessage("I'm sorry, but you ")
+		.then("don't seem to have enough money...")
+		.color(ChatColor.DARK_RED);
+			
+		SimpleMessage message = new SimpleMessage(msg);
+		message.setSourceLabel(new FancyMessage());
+		
+		ChatMenu messageChat = new BioptionChatMenu(chat, 
+					new InnAction(cost, qp, message)
+		, null);			
+
+		messageChat.show(player);
+	}
+	
+}

--- a/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/InnNPC.java
@@ -161,7 +161,7 @@ public class InnNPC extends SimpleBioptionNPC {
 		.color(ChatColor.DARK_RED);
 			
 		SimpleMessage message = new SimpleMessage(msg);
-		message.setSourceLabel(new FancyMessage());
+		message.setSourceLabel(new FancyMessage(this.name));
 		
 		ChatMenu messageChat = new BioptionChatMenu(chat, 
 					new InnAction(cost, qp, message)

--- a/src/nmt/minecraft/QuestManager/NPC/MuteNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/MuteNPC.java
@@ -88,11 +88,13 @@ public class MuteNPC extends NPC {
 		
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.entity.setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.getEntity().setCustomName((String) map.get("name"));
+
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());
@@ -109,14 +111,14 @@ public class MuteNPC extends NPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("type", getEntity().getType());
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();

--- a/src/nmt/minecraft/QuestManager/NPC/MuteNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/MuteNPC.java
@@ -26,7 +26,7 @@ import org.bukkit.inventory.EntityEquipment;
  * <i>equipment</i>:<br />
  * &nbsp;&nbsp;[valid {@link nmt.minecraft.QuestManager.Configuration.EquipmentConfiguration}]
  */
-public class MuteNPC extends NPC {
+public class MuteNPC extends SimpleNPC {
 	
 	/**
 	 * Registers this class as configuration serializable with all defined 
@@ -63,6 +63,10 @@ public class MuteNPC extends NPC {
 		}
 	}
 
+	private MuteNPC(Location startingLoc) {
+		super(startingLoc);
+	}
+
 	public static MuteNPC valueOf(Map<String, Object> map) {
 		if (map == null || !map.containsKey("name") || !map.containsKey("type") 
 				 || !map.containsKey("location") || !map.containsKey("equipment")) {
@@ -70,8 +74,6 @@ public class MuteNPC extends NPC {
 					+ (map.containsKey("name") ? ": " + map.get("name") : ""));
 			return null;
 		}
-		
-		MuteNPC npc = new MuteNPC();
 		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
@@ -88,9 +90,12 @@ public class MuteNPC extends NPC {
 		
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
+		
+		MuteNPC npc = new MuteNPC(loc);
 
 		loc.getChunk();
 		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.setStartingLoc(loc);
 		npc.getEntity().setCustomName((String) map.get("name"));
 
 		if (npc.getEntity() instanceof LivingEntity) {
@@ -128,10 +133,6 @@ public class MuteNPC extends NPC {
 	
 		
 		return map;
-	}
-	
-	private MuteNPC() {
-		super();
 	}
 
 	@Override

--- a/src/nmt/minecraft/QuestManager/NPC/NPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/NPC.java
@@ -48,7 +48,9 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 		}
 		
 		//try and load last chunk the entity was in
-		entity.getLocation().getChunk();
+		if (entity != null) {
+			entity.getLocation().getChunk();
+		}
 		
 		//cache has expired (new entity ID, etc) so grab entity
 		for (World w : Bukkit.getWorlds())

--- a/src/nmt/minecraft/QuestManager/NPC/NPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/NPC.java
@@ -9,9 +9,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 public abstract class NPC implements ConfigurationSerializable, Listener, Tickable {
@@ -86,6 +88,28 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 		if (e.getRightClicked().getUniqueId().equals(id)) {
 			e.setCancelled(true);
 			this.interact(e.getPlayer());
+		}
+	}
+	
+	@EventHandler
+	public void onEntityHurt(EntityDamageEvent e) {
+		if (!e.getEntity().getUniqueId().equals(id)) {
+			return;
+		}
+			
+		//grab the damage. if it's gonna kill us, just take no damage?
+		
+		
+		Entity ent = getEntity();
+		if (!(ent instanceof LivingEntity)) {
+			return;
+		}
+		
+		LivingEntity l = (LivingEntity) e;
+		
+		
+		if (e.getDamage() >= l.getHealth()){
+			e.setDamage(0.0);
 		}
 	}
 	

--- a/src/nmt/minecraft/QuestManager/NPC/NPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/NPC.java
@@ -3,6 +3,7 @@ package nmt.minecraft.QuestManager.NPC;
 import java.util.UUID;
 
 import nmt.minecraft.QuestManager.QuestManagerPlugin;
+import nmt.minecraft.QuestManager.Scheduling.Tickable;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -13,7 +14,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
-public abstract class NPC implements ConfigurationSerializable, Listener {
+public abstract class NPC implements ConfigurationSerializable, Listener, Tickable {
 	
 	/**
 	 * Cache value for saving lookup times for entities

--- a/src/nmt/minecraft/QuestManager/NPC/NPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/NPC.java
@@ -42,7 +42,7 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 	 * @return The entity attached to our UUID, or NULL if none is found
 	 */
 	public Entity getEntity() {
-		if (entity != null && !entity.isDead() && entity.getUniqueId().equals(id)) {
+		if (entity != null && entity.isValid() && !entity.isDead() && entity.getUniqueId().equals(id)) {
 			//still cached
 			return entity;
 		}
@@ -50,6 +50,8 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 		//try and load last chunk the entity was in
 		if (entity != null) {
 			entity.getLocation().getChunk();
+		} else {
+			System.out.println("entity is null: " + name);
 		}
 		
 		//cache has expired (new entity ID, etc) so grab entity
@@ -102,8 +104,7 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 			return;
 		}
 			
-		//grab the damage. if it's gonna kill us, just take no damage?
-		
+		//grab the damage. if it's gonna kill us, just take no damage? 
 		
 		Entity ent = getEntity();
 		if (!(ent instanceof LivingEntity)) {
@@ -111,7 +112,6 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 		}
 		
 		LivingEntity l = (LivingEntity) ent;
-		
 		
 		if (e.getDamage() >= l.getHealth()){
 			e.setDamage(0.0);

--- a/src/nmt/minecraft/QuestManager/NPC/NPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/NPC.java
@@ -1,8 +1,11 @@
 package nmt.minecraft.QuestManager.NPC;
 
+import java.util.UUID;
+
 import nmt.minecraft.QuestManager.QuestManagerPlugin;
 
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -12,7 +15,15 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 public abstract class NPC implements ConfigurationSerializable, Listener {
 	
-	protected Entity entity;
+	/**
+	 * Cache value for saving lookup times for entities
+	 */
+	private Entity entity;
+	
+	/**
+	 * The actual ID of the entity we're monitoring
+	 */
+	protected UUID id;
 	
 	protected String name;
 	
@@ -20,8 +31,48 @@ public abstract class NPC implements ConfigurationSerializable, Listener {
 		Bukkit.getPluginManager().registerEvents(this, QuestManagerPlugin.questManagerPlugin);
 	}
 	
+	/**
+	 * Returns the entity this NPC is attached to.<br />
+	 * This method attempts to save cycles by caching the last known entity to
+	 * represent our UUID'd creature. If the cache is no longer valid, an entire
+	 * sweep of worlds and entities is performed to lookup the entity.
+	 * @return The entity attached to our UUID, or NULL if none is found
+	 */
 	public Entity getEntity() {
-		return entity;
+		if (entity != null && !entity.isDead() && entity.getUniqueId().equals(id)) {
+			//still cached
+			return entity;
+		}
+		
+		//cache has expired (new entity ID, etc) so grab entity
+		for (World w : Bukkit.getWorlds())
+		for (Entity e : w.getEntities()) {
+			if (e.getUniqueId().equals(id)) {
+				entity = e;
+				return e;
+			}
+		}
+		
+		//unable to find entity!
+		return null;
+		
+	}
+	
+	/**
+	 * Register an entity to this NPC. This method also updates the ID of this npc
+	 * @param entity
+	 */
+	public void setEntity(Entity entity) {
+		this.entity = entity;
+		this.id = entity.getUniqueId();
+	}
+	
+	/**
+	 * Specify the ID used for this entity
+	 * @param id
+	 */
+	public void setID(UUID id) {
+		this.id = id;
 	}
 	
 	public String getName() {
@@ -31,7 +82,7 @@ public abstract class NPC implements ConfigurationSerializable, Listener {
 	
 	@EventHandler
 	public void onPlayerInteract(PlayerInteractEntityEvent e) {
-		if (e.getRightClicked().equals(entity)) {
+		if (e.getRightClicked().getUniqueId().equals(id)) {
 			e.setCancelled(true);
 			this.interact(e.getPlayer());
 		}

--- a/src/nmt/minecraft/QuestManager/NPC/NPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/NPC.java
@@ -47,6 +47,9 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 			return entity;
 		}
 		
+		//try and load last chunk the entity was in
+		entity.getLocation().getChunk();
+		
 		//cache has expired (new entity ID, etc) so grab entity
 		for (World w : Bukkit.getWorlds())
 		for (Entity e : w.getEntities()) {
@@ -105,7 +108,7 @@ public abstract class NPC implements ConfigurationSerializable, Listener, Tickab
 			return;
 		}
 		
-		LivingEntity l = (LivingEntity) e;
+		LivingEntity l = (LivingEntity) ent;
 		
 		
 		if (e.getDamage() >= l.getHealth()){

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleBioptionNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleBioptionNPC.java
@@ -75,14 +75,14 @@ public class SimpleBioptionNPC extends NPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("type", getEntity().getType());
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();
@@ -124,11 +124,13 @@ public class SimpleBioptionNPC extends NPC {
 		
 		npc.name = (String) map.get("name");
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.entity.setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.getEntity().setCustomName((String) map.get("name"));
+
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleBioptionNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleBioptionNPC.java
@@ -27,7 +27,7 @@ import org.bukkit.inventory.EntityEquipment;
  * @author Skyler
  *
  */
-public class SimpleBioptionNPC extends NPC {
+public class SimpleBioptionNPC extends SimpleNPC {
 
 	/**
 	 * Registers this class as configuration serializable with all defined 
@@ -66,8 +66,8 @@ public class SimpleBioptionNPC extends NPC {
 	
 	protected BioptionMessage chat;
 	
-	protected SimpleBioptionNPC() {
-		super();
+	protected SimpleBioptionNPC(Location startingLoc) {
+		super(startingLoc);
 	}
 		
 	@Override
@@ -105,7 +105,6 @@ public class SimpleBioptionNPC extends NPC {
 			return null;
 		}
 		
-		SimpleBioptionNPC npc = new SimpleBioptionNPC();
 		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
@@ -120,6 +119,8 @@ public class SimpleBioptionNPC extends NPC {
 		LocationState ls = (LocationState) map.get("location");
 		Location loc = ls.getLocation();
 		
+
+		SimpleBioptionNPC npc = new SimpleBioptionNPC(loc);
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
 		npc.name = (String) map.get("name");

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleChatNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleChatNPC.java
@@ -76,14 +76,14 @@ public class SimpleChatNPC extends NPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("type", getEntity().getType());
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();
@@ -123,12 +123,14 @@ public class SimpleChatNPC extends NPC {
 		
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.name = (String) map.get("name");
-		npc.entity.setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.name = (String) map.get("name");
+		npc.getEntity().setCustomName((String) map.get("name"));
+
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleChatNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleChatNPC.java
@@ -28,7 +28,7 @@ import org.bukkit.inventory.EntityEquipment;
  * @author Skyler
  *
  */
-public class SimpleChatNPC extends NPC {
+public class SimpleChatNPC extends SimpleNPC {
 
 	/**
 	 * Registers this class as configuration serializable with all defined 
@@ -67,8 +67,8 @@ public class SimpleChatNPC extends NPC {
 	
 	private SimpleMessage chat;
 	
-	private SimpleChatNPC() {
-		super();
+	private SimpleChatNPC(Location startingLoc) {
+		super(startingLoc);
 	}
 		
 	@Override
@@ -106,8 +106,6 @@ public class SimpleChatNPC extends NPC {
 			return null;
 		}
 		
-		SimpleChatNPC npc = new SimpleChatNPC();
-		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
 			YamlConfiguration tmp = new YamlConfiguration();
@@ -123,9 +121,12 @@ public class SimpleChatNPC extends NPC {
 		
 		EntityType type = EntityType.valueOf((String) map.get("type"));
 		
+		
+		SimpleChatNPC npc = new SimpleChatNPC(loc);
 
 		loc.getChunk();
 		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.setStartingLoc(loc);
 		npc.name = (String) map.get("name");
 		npc.getEntity().setCustomName((String) map.get("name"));
 
@@ -163,6 +164,11 @@ public class SimpleChatNPC extends NPC {
 	protected void interact(Player player) {
 		ChatMenu messageChat = new SimpleChatMenu(chat.getFormattedMessage());
 		messageChat.show(player);
+	}
+	
+	@Override
+	public void tick() {
+		
 	}
 
 }

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleNPC.java
@@ -1,0 +1,67 @@
+package nmt.minecraft.QuestManager.NPC;
+
+import nmt.minecraft.QuestManager.Scheduling.DispersedScheduler;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+
+/**
+ * Describes NPCs with simple movement pattern: they occasionally attempt to
+ * move back to their original spot
+ * @author Skyler
+ *
+ */
+public abstract class SimpleNPC extends NPC {
+	
+	private Location startingLoc;
+	
+	/**
+	 * Defines how far an NPC can be when they are ticked before being teleported
+	 * back to their original location
+	 */
+	private static final double range = 20.0;
+	
+	protected SimpleNPC(Location startingLoc) {
+		super();
+		this.startingLoc = startingLoc;
+		
+		DispersedScheduler.getScheduler().register(this);
+	}
+	
+	/**
+	 * Motivate entity to move back to the original location, if we hve one set
+	 */
+	@Override
+	public void tick() {
+		Entity e = getEntity();
+		
+		if (e == null || startingLoc == null) {
+			return;
+		}
+		
+		if (!e.getLocation().getWorld().getName().equals(
+				startingLoc.getWorld().getName()) 
+				|| e.getLocation().distance(startingLoc) > range) {
+			//if we're in a different world (whut?) or range is too big,
+			//teleport them back!
+			e.teleport(startingLoc);
+		}
+	}
+
+	/**
+	 * @return the startingLoc
+	 */
+	public Location getStartingLoc() {
+		return startingLoc;
+	}
+
+	/**
+	 * @param startingLoc the startingLoc to set
+	 */
+	public void setStartingLoc(Location startingLoc) {
+		this.startingLoc = startingLoc;
+	}
+	
+	
+	
+}

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
@@ -192,7 +192,7 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		if (qp.hasCompleted(quest.getName())) {
 			//already completed it
 			messageChat = ChatMenu.getDefaultMenu(afterMessage);
-		} else if (qp.isInQuest(quest.getName())) {
+		} else if (qp.isInQuest(quest.getName()) && !quest.isRepeatable()) {
 			//is currently in it
 			
 			//Is this the possible end?

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
@@ -90,9 +90,11 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		
 		map.put("equipment", econ);
 		
-		map.put("message", chat);
-	
-		
+		map.put("firstmessage", chat);
+		map.put("duringmessage", duringMessage);
+		map.put("postmessage", afterMessage);
+		map.put("badrequirementmessage", altMessage);
+				
 		return map;
 	}
 	

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
@@ -189,10 +189,10 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		
 		ChatMenu messageChat = null;
 		
-		if (qp.hasCompleted(quest.getName())) {
+		if (qp.hasCompleted(quest.getName())  && !quest.isRepeatable()) {
 			//already completed it
 			messageChat = ChatMenu.getDefaultMenu(afterMessage);
-		} else if (qp.isInQuest(quest.getName()) && !quest.isRepeatable()) {
+		} else if (qp.isInQuest(quest.getName())) {
 			//is currently in it
 			
 			//Is this the possible end?

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
@@ -189,7 +189,7 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		
 		ChatMenu messageChat = null;
 		
-		if (qp.hasCompleted(quest.getName())  && !quest.isRepeatable()) {
+		if (!quest.isRepeatable() && qp.hasCompleted(quest.getName())) {
 			//already completed it
 			messageChat = ChatMenu.getDefaultMenu(afterMessage);
 		} else if (qp.isInQuest(quest.getName())) {

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
@@ -69,7 +69,11 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 			return alias;
 		}
 	}
+
 	
+	private SimpleQuestStartNPC(Location startingLoc) {
+		super(startingLoc);
+	}
 	@Override
 	public Map<String, Object> serialize() {
 		Map<String, Object> map = new HashMap<String, Object>(4);
@@ -108,9 +112,6 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 			return null;
 		}
 		
-		SimpleQuestStartNPC npc = new SimpleQuestStartNPC();
-		npc.isEnd = false;
-		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
 			YamlConfiguration tmp = new YamlConfiguration();
@@ -125,6 +126,10 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		Location loc = ls.getLocation();
 		
 		EntityType type = EntityType.valueOf((String) map.get("type"));
+		
+		
+		SimpleQuestStartNPC npc = new SimpleQuestStartNPC(loc);
+		npc.isEnd = false;
 		
 		npc.name = (String) map.get("name");
 		

--- a/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/SimpleQuestStartNPC.java
@@ -75,14 +75,14 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("type", getEntity().getType());
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();
@@ -128,11 +128,13 @@ public class SimpleQuestStartNPC extends SimpleBioptionNPC {
 		
 		npc.name = (String) map.get("name");
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.entity.setCustomName((String) map.get("name"));
+		//load the chunk
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.getEntity().setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());

--- a/src/nmt/minecraft/QuestManager/NPC/TeleportNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/TeleportNPC.java
@@ -74,16 +74,16 @@ public class TeleportNPC extends SimpleBioptionNPC {
 		Map<String, Object> map = new HashMap<String, Object>(4);
 		
 		map.put("name", name);
-		map.put("type", entity.getType());
+		map.put("type", getEntity().getType());
 		map.put("cost", cost);
 		map.put("destination", new LocationState(destination));
-		map.put("location", new LocationState(entity.getLocation()));
+		map.put("location", new LocationState(getEntity().getLocation()));
 		
 		EquipmentConfiguration econ;
 		
-		if (entity instanceof LivingEntity) {
+		if (getEntity() instanceof LivingEntity) {
 			econ = new EquipmentConfiguration(
-					((LivingEntity) entity).getEquipment()
+					((LivingEntity) getEntity()).getEquipment()
 					);
 		} else {
 			econ = new EquipmentConfiguration();
@@ -136,11 +136,13 @@ public class TeleportNPC extends SimpleBioptionNPC {
 		
 		npc.destination = ((LocationState) map.get("destination")).getLocation();
 		
-		npc.entity = loc.getWorld().spawnEntity(loc, type);
-		npc.entity.setCustomName((String) map.get("name"));
 
-		if (npc.entity instanceof LivingEntity) {
-			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+		loc.getChunk();
+		npc.setEntity(loc.getWorld().spawnEntity(loc, type));
+		npc.getEntity().setCustomName((String) map.get("name"));
+
+		if (npc.getEntity() instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.getEntity()).getEquipment();
 			equipment.setHelmet(econ.getHead());
 			equipment.setChestplate(econ.getChest());
 			equipment.setLeggings(econ.getLegs());

--- a/src/nmt/minecraft/QuestManager/NPC/TeleportNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/TeleportNPC.java
@@ -68,6 +68,11 @@ public class TeleportNPC extends SimpleBioptionNPC {
 			return alias;
 		}
 	}
+
+	
+	private TeleportNPC(Location startingLoc) {
+		super(startingLoc);
+	}
 	
 	@Override
 	public Map<String, Object> serialize() {
@@ -113,8 +118,6 @@ public class TeleportNPC extends SimpleBioptionNPC {
 			return null;
 		}
 		
-		TeleportNPC npc = new TeleportNPC();
-		
 		EquipmentConfiguration econ = new EquipmentConfiguration();
 		try {
 			YamlConfiguration tmp = new YamlConfiguration();
@@ -129,6 +132,8 @@ public class TeleportNPC extends SimpleBioptionNPC {
 		Location loc = ls.getLocation();
 		
 		EntityType type = EntityType.valueOf((String) map.get("type"));
+		
+		TeleportNPC npc = new TeleportNPC(loc);
 		
 		npc.name = (String) map.get("name");
 		

--- a/src/nmt/minecraft/QuestManager/NPC/TeleportNPC.java
+++ b/src/nmt/minecraft/QuestManager/NPC/TeleportNPC.java
@@ -1,0 +1,179 @@
+package nmt.minecraft.QuestManager.NPC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import nmt.minecraft.QuestManager.QuestManagerPlugin;
+import nmt.minecraft.QuestManager.Configuration.EquipmentConfiguration;
+import nmt.minecraft.QuestManager.Configuration.Utils.LocationState;
+import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.UI.ChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.BioptionChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.Action.TeleportAction;
+import nmt.minecraft.QuestManager.UI.Menu.Message.BioptionMessage;
+import nmt.minecraft.QuestManager.UI.Menu.Message.SimpleMessage;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+
+/**
+ * NPC which offers to take a player and move them, for a fee?
+ * @author Skyler
+ *
+ */
+public class TeleportNPC extends SimpleBioptionNPC {
+	
+	/**
+	 * Registers this class as configuration serializable with all defined 
+	 * {@link aliases aliases}
+	 */
+	public static void registerWithAliases() {
+		for (aliases alias : aliases.values()) {
+			ConfigurationSerialization.registerClass(TeleportNPC.class, alias.getAlias());
+		}
+	}
+	
+	/**
+	 * Registers this class as configuration serializable with only the default alias
+	 */
+	public static void registerWithoutAliases() {
+		ConfigurationSerialization.registerClass(TeleportNPC.class);
+	}
+	
+
+	private enum aliases {
+		FULL("nmt.minecraft.QuestManager.NPC.TeleportNPC"),
+		DEFAULT(TeleportNPC.class.getName()),
+		SHORT("TeleportNPC"),
+		ALT("FerryNPC"),
+		INFORMAL("TPNPC");
+		
+		private String alias;
+		
+		private aliases(String alias) {
+			this.alias = alias;
+		}
+		
+		public String getAlias() {
+			return alias;
+		}
+	}
+	
+	@Override
+	public Map<String, Object> serialize() {
+		Map<String, Object> map = new HashMap<String, Object>(4);
+		
+		map.put("name", name);
+		map.put("type", entity.getType());
+		map.put("cost", cost);
+		map.put("destination", new LocationState(destination));
+		map.put("location", new LocationState(entity.getLocation()));
+		
+		EquipmentConfiguration econ;
+		
+		if (entity instanceof LivingEntity) {
+			econ = new EquipmentConfiguration(
+					((LivingEntity) entity).getEquipment()
+					);
+		} else {
+			econ = new EquipmentConfiguration();
+		}
+		
+		map.put("equipment", econ);
+		
+		map.put("message", chat);
+	
+		
+		return map;
+	}
+	
+	public static TeleportNPC valueOf(Map<String, Object> map) {
+		if (map == null || !map.containsKey("name") || !map.containsKey("type") 
+				 || !map.containsKey("location") || !map.containsKey("equipment")
+				  || !map.containsKey("message") || !map.containsKey("cost") 
+				|| !map.containsKey("destination")) {
+			QuestManagerPlugin.questManagerPlugin.getLogger().warning("Invalid NPC info! "
+					+ (map.containsKey("name") ? ": " + map.get("name") : ""));
+			return null;
+		}
+		
+		TeleportNPC npc = new TeleportNPC();
+		
+		EquipmentConfiguration econ = new EquipmentConfiguration();
+		try {
+			YamlConfiguration tmp = new YamlConfiguration();
+			tmp.createSection("key",  (Map<?, ?>) map.get("equipment"));
+			econ.load(tmp.getConfigurationSection("key"));
+		} catch (InvalidConfigurationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		LocationState ls = (LocationState) map.get("location");
+		Location loc = ls.getLocation();
+		
+		EntityType type = EntityType.valueOf((String) map.get("type"));
+		
+		npc.name = (String) map.get("name");
+		
+		npc.cost = (int) map.get("cost");
+		
+		npc.destination = ((LocationState) map.get("destination")).getLocation();
+		
+		npc.entity = loc.getWorld().spawnEntity(loc, type);
+		npc.entity.setCustomName((String) map.get("name"));
+
+		if (npc.entity instanceof LivingEntity) {
+			EntityEquipment equipment = ((LivingEntity) npc.entity).getEquipment();
+			equipment.setHelmet(econ.getHead());
+			equipment.setChestplate(econ.getChest());
+			equipment.setLeggings(econ.getLegs());
+			equipment.setBoots(econ.getBoots());
+			equipment.setItemInHand(econ.getHeld());
+			
+		}
+		
+		npc.chat = (BioptionMessage) map.get("message");		
+		
+		//provide our npc's name, unless we don't have one!
+		if (npc.name != null && !npc.name.equals("")) {
+			FancyMessage label = new FancyMessage(npc.name);
+			npc.chat.setSourceLabel(label);			
+		}
+		
+		return npc;
+	}
+		
+	private int cost;
+	
+	private Location destination;
+		
+	@Override
+	protected void interact(Player player) {
+		
+		QuestPlayer qp = QuestManagerPlugin.questManagerPlugin.getPlayerManager()
+				.getPlayer(player.getUniqueId());
+		
+		FancyMessage msg = new FancyMessage("I apologize, but you ")
+		.then("don't seem to have enough for fare...")
+		.color(ChatColor.DARK_RED);
+			
+		SimpleMessage message = new SimpleMessage(msg);
+		message.setSourceLabel(new FancyMessage(this.name));
+		
+		ChatMenu messageChat = new BioptionChatMenu(chat, 
+					new TeleportAction(cost, destination, qp, message)
+		, null);			
+
+		messageChat.show(player);
+	}
+	
+}

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -418,6 +418,11 @@ public class QuestPlayer implements Participant, Listener {
 	 */
 	public void setMoney(int money) {
 		this.money = money;
+		if (player.isOnline())
+		if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
+					.getWorlds().contains(player.getPlayer().getWorld().getName())) {
+			player.getPlayer().setLevel(money);
+		}
 	}
 	
 	/**
@@ -426,6 +431,11 @@ public class QuestPlayer implements Participant, Listener {
 	 */
 	public void addMoney(int money) {
 		this.money += money;
+		if (player.isOnline())
+			if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
+						.getWorlds().contains(player.getPlayer().getWorld().getName())) {
+				player.getPlayer().setLevel(money);
+			}
 	}
 
 	public void setTitle(String title) {
@@ -588,7 +598,6 @@ public class QuestPlayer implements Participant, Listener {
 			return;
 		}
 		
-		System.out.println("amount: " + e.getAmount());
 		money += e.getAmount();
 		p.setLevel(money);
 		

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -54,6 +54,8 @@ public class QuestPlayer implements Participant, Listener {
 	
 	private int fame;
 	
+	private int money;
+	
 	private String title;
 	
 	private Location questPortal;
@@ -135,7 +137,8 @@ public class QuestPlayer implements Participant, Listener {
 	
 	private QuestPlayer() {
 		this.fame = 0;
-		this.title = "";
+		this.money = 0;
+		this.title = "The Unknown";
 		Bukkit.getPluginManager().registerEvents(this, QuestManagerPlugin.questManagerPlugin);
 		; //do nothing. This is for non-redundant defining of QuestPlayers from config
 	}
@@ -398,6 +401,28 @@ public class QuestPlayer implements Participant, Listener {
 		this.fame = fame;
 	}
 	
+	/**
+	 * @return the money
+	 */
+	public int getMoney() {
+		return money;
+	}
+
+	/**
+	 * @param money the money to set
+	 */
+	public void setMoney(int money) {
+		this.money = money;
+	}
+	
+	/**
+	 * Add some money to the player's wallet
+	 * @param money
+	 */
+	public void addMoney(int money) {
+		this.money += money;
+	}
+
 	public void setTitle(String title) {
 		this.title = title;
 	}
@@ -438,6 +463,7 @@ public class QuestPlayer implements Participant, Listener {
 		Map<String, Object> map = new HashMap<String, Object>(3);
 		map.put("title", title);
 		map.put("fame", fame);
+		map.put("money", money);
 		map.put("id", player.getUniqueId().toString());
 		map.put("portalloc", this.questPortal);
 		map.put("completedquests", completedQuests);
@@ -454,7 +480,7 @@ public class QuestPlayer implements Participant, Listener {
 	public static QuestPlayer valueOf(Map<String, Object> map) {
 		if (map == null || !map.containsKey("id") || !map.containsKey("fame") 
 				 || !map.containsKey("title") || !map.containsKey("completedquests")
-				 || !map.containsKey("portalloc")) {
+				 || !map.containsKey("portalloc") || !map.containsKey("money")) {
 			QuestManagerPlugin.questManagerPlugin.getLogger().warning("Invalid Quest Player! "
 					+ (map.containsKey("id") ? ": " + map.get("id") : ""));
 			return null;
@@ -471,6 +497,7 @@ public class QuestPlayer implements Participant, Listener {
 		}
 		
 		qp.fame = (int) map.get("fame");
+		qp.money = (int) map.get("money");
 		qp.title = (String) map.get("title");
 		qp.completedQuests = (List<String>) map.get("completedquests");
 		

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -31,6 +31,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -635,6 +636,27 @@ public class QuestPlayer implements Participant, Listener {
 	}
 	
 	@EventHandler
+	public void onPlayerDeath(PlayerDeathEvent e) {
+		if (!player.isOnline()) {
+			return;
+		}
+		
+		Player p = player.getPlayer().getPlayer();
+		
+		if (!p.getUniqueId().equals(e.getEntity().getUniqueId())) {
+			return;
+		}
+		
+		if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
+				.getWorlds().contains(p.getWorld().getName())) {
+			return;
+		}
+		
+		e.setDroppedExp(0);
+		
+	}
+	
+	@EventHandler
 	public void onPlayerRespawn(PlayerRespawnEvent e) {
 
 		if (!player.getUniqueId().equals(e.getPlayer().getUniqueId())) {
@@ -659,6 +681,9 @@ public class QuestPlayer implements Participant, Listener {
 		PortalPlayerSession ps = mvp.getPortalSession(e.getPlayer());
 		ps.playerDidTeleport(questPortal);
 		ps.setTeleportTime(new Date());
+		
+		e.getPlayer().setLevel(QuestManagerPlugin.questManagerPlugin.getPlayerManager().getPlayer(
+				e.getPlayer().getUniqueId()).getMoney());
 		
 	}
 	

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -140,6 +140,7 @@ public class QuestPlayer implements Participant {
 		this();
 		this.player = player;
 		this.currentQuests = new LinkedList<Quest>();
+		this.completedQuests = new LinkedList<String>();
 		this.history = new History();
 		
 		
@@ -334,6 +335,7 @@ public class QuestPlayer implements Participant {
 	public void addQuest(Quest quest) {
 		currentQuests.add(quest);
 		history.addHistoryEvent(new HistoryEvent("Accepted the quest \"" + quest.getName() +"\""));
+		addQuestBook();
 		updateQuestBook();
 	}
 	

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -3,6 +3,7 @@ package nmt.minecraft.QuestManager.Player;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -340,14 +341,29 @@ public class QuestPlayer implements Participant {
 	}
 	
 	public boolean removeQuest(Quest quest) {
-		return currentQuests.remove(quest);
+		
+		if (currentQuests.isEmpty()) {
+			return false;
+		}
+		
+		Iterator<Quest> it = currentQuests.iterator();
+		
+		while (it.hasNext()) {
+			Quest q = it.next();
+			if (q.equals(quest)) {
+				it.remove();
+				return true;
+			}
+		}
+		
+		return false;
 	}
 	
 	public void completeQuest(Quest quest) {
 		if (!completedQuests.contains(quest.getName())) {
 			completedQuests.add(quest.getName());			
 		}
-		currentQuests.remove(quest);
+		removeQuest(quest);
 		
 		history.addHistoryEvent(
 				new HistoryEvent("Completed the quest \"" + quest.getName() + "\""));

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -344,7 +344,9 @@ public class QuestPlayer implements Participant {
 	}
 	
 	public void completeQuest(Quest quest) {
-		completedQuests.add(quest.getName());
+		if (!completedQuests.contains(quest.getName())) {
+			completedQuests.add(quest.getName());			
+		}
 		currentQuests.remove(quest);
 		
 		history.addHistoryEvent(

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -653,6 +653,7 @@ public class QuestPlayer implements Participant, Listener {
 		}
 		
 		e.setDroppedExp(0);
+		e.setNewLevel(money);
 		
 	}
 	
@@ -682,8 +683,6 @@ public class QuestPlayer implements Participant, Listener {
 		ps.playerDidTeleport(questPortal);
 		ps.setTeleportTime(new Date());
 		
-		e.getPlayer().setLevel(QuestManagerPlugin.questManagerPlugin.getPlayerManager().getPlayer(
-				e.getPlayer().getUniqueId()).getMoney());
 		
 	}
 	

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -163,7 +163,10 @@ public class QuestPlayer implements Participant, Listener {
 		this.completedQuests = new LinkedList<String>();
 		this.history = new History();
 		
-		
+		if (player.isOnline()) {
+			Player p = player.getPlayer();
+			questPortal = p.getWorld().getSpawnLocation();
+		}
 	}
 	
 	

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -584,10 +584,11 @@ public class QuestPlayer implements Participant, Listener {
 		}
 		
 		if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
-				.getWorlds().contains(p.getWorld())) {
+				.getWorlds().contains(p.getWorld().getName())) {
 			return;
 		}
 		
+		System.out.println("amount: " + e.getAmount());
 		money += e.getAmount();
 		p.setLevel(money);
 		

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -429,7 +429,7 @@ public class QuestPlayer implements Participant, Listener {
 		if (player.isOnline())
 		if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
 					.getWorlds().contains(player.getPlayer().getWorld().getName())) {
-			player.getPlayer().setLevel(money);
+			player.getPlayer().setLevel(this.money);
 		}
 	}
 	
@@ -442,7 +442,7 @@ public class QuestPlayer implements Participant, Listener {
 		if (player.isOnline())
 			if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
 						.getWorlds().contains(player.getPlayer().getWorld().getName())) {
-				player.getPlayer().setLevel(money);
+				player.getPlayer().setLevel(this.money);
 			}
 	}
 

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -464,7 +464,11 @@ public class QuestPlayer implements Participant, Listener {
 				(String) map.get("id")));
 		QuestPlayer qp = new QuestPlayer(player);
 		
-		qp.questPortal = ((LocationState) map.get("portalloc")).getLocation();
+		if (map.get("portalloc") == null) {
+			qp.questPortal = null;
+		} else {
+			qp.questPortal = ((LocationState) map.get("portalloc")).getLocation();
+		}
 		
 		qp.fame = (int) map.get("fame");
 		qp.title = (String) map.get("title");

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -2,6 +2,7 @@ package nmt.minecraft.QuestManager.Player;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -32,10 +33,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 
+import com.onarandombox.MultiversePortals.MultiversePortals;
+import com.onarandombox.MultiversePortals.PortalPlayerSession;
 import com.onarandombox.MultiversePortals.event.MVPortalEvent;
 
 /**
@@ -606,10 +610,6 @@ public class QuestPlayer implements Participant, Listener {
 	
 	@EventHandler
 	public void onPlayerInteract(PlayerInteractEvent e) {
-		if (player == null) {
-			return;
-			//just wiat for it to figure itself out
-		}
 		
 		if (!player.isOnline()) {
 			return;
@@ -631,6 +631,34 @@ public class QuestPlayer implements Participant, Listener {
 				updateQuestBook();
 			}
 		}
+		
+	}
+	
+	@EventHandler
+	public void onPlayerRespawn(PlayerRespawnEvent e) {
+
+		if (!player.getUniqueId().equals(e.getPlayer().getUniqueId())) {
+			return;
+		}
+
+		if (!QuestManagerPlugin.questManagerPlugin.getPluginConfiguration()
+				.getWorlds().contains(e.getRespawnLocation().getWorld().getName())) {
+			return;
+		}
+		
+		//in a quest world, so put them back to their last checkpoint
+		e.setRespawnLocation(
+				this.questPortal);
+		MultiversePortals mvp = (MultiversePortals) Bukkit.getPluginManager().getPlugin("Multiverse-Portals");
+		
+		if (mvp == null) {
+			System.out.println("null");
+			return;
+		}
+		
+		PortalPlayerSession ps = mvp.getPortalSession(e.getPlayer());
+		ps.playerDidTeleport(questPortal);
+		ps.setTeleportTime(new Date());
 		
 	}
 	

--- a/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
+++ b/src/nmt/minecraft/QuestManager/Player/QuestPlayer.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import nmt.minecraft.QuestManager.QuestManagerPlugin;
+import nmt.minecraft.QuestManager.Configuration.Utils.LocationState;
 import nmt.minecraft.QuestManager.Quest.Goal;
 import nmt.minecraft.QuestManager.Quest.Quest;
 import nmt.minecraft.QuestManager.Quest.History.History;
@@ -135,6 +136,7 @@ public class QuestPlayer implements Participant, Listener {
 	private QuestPlayer() {
 		this.fame = 0;
 		this.title = "";
+		Bukkit.getPluginManager().registerEvents(this, QuestManagerPlugin.questManagerPlugin);
 		; //do nothing. This is for non-redundant defining of QuestPlayers from config
 	}
 	
@@ -437,6 +439,7 @@ public class QuestPlayer implements Participant, Listener {
 		map.put("title", title);
 		map.put("fame", fame);
 		map.put("id", player.getUniqueId().toString());
+		map.put("portalloc", this.questPortal);
 		map.put("completedquests", completedQuests);
 		
 		return map;
@@ -450,7 +453,8 @@ public class QuestPlayer implements Participant, Listener {
 	@SuppressWarnings("unchecked")
 	public static QuestPlayer valueOf(Map<String, Object> map) {
 		if (map == null || !map.containsKey("id") || !map.containsKey("fame") 
-				 || !map.containsKey("title") || !map.containsKey("completedquests")) {
+				 || !map.containsKey("title") || !map.containsKey("completedquests")
+				 || !map.containsKey("portalloc")) {
 			QuestManagerPlugin.questManagerPlugin.getLogger().warning("Invalid Quest Player! "
 					+ (map.containsKey("id") ? ": " + map.get("id") : ""));
 			return null;
@@ -459,6 +463,8 @@ public class QuestPlayer implements Participant, Listener {
 		OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(
 				(String) map.get("id")));
 		QuestPlayer qp = new QuestPlayer(player);
+		
+		qp.questPortal = ((LocationState) map.get("portalloc")).getLocation();
 		
 		qp.fame = (int) map.get("fame");
 		qp.title = (String) map.get("title");

--- a/src/nmt/minecraft/QuestManager/Quest/Quest.java
+++ b/src/nmt/minecraft/QuestManager/Quest/Quest.java
@@ -493,6 +493,7 @@ public class Quest implements Listener {
 			update();
 
 			for (QuestPlayer p : players) {
+				p.addQuestBook();
 				p.updateQuestBook();
 			}
 		}

--- a/src/nmt/minecraft/QuestManager/Quest/Quest.java
+++ b/src/nmt/minecraft/QuestManager/Quest/Quest.java
@@ -48,22 +48,6 @@ import org.bukkit.inventory.ItemStack;
  * stopped, and halted. Quests must also keep track of involved players and
  * any parts of the quest involved (future work?). <br />
  * 
- * It doesn't have to, but I see this going as follows:<br />
- * Another quest type class/iterface implements the quest interface and makes
- * it more specific (duh). For example, maybe a PVPQuest interface or an
- * ExplorationQuest interface, etc. And then down in the gnitty gritty
- * specifics, maybe a whole host of quest classes that implement the interface
- * and have the actual implementation stuff? <br />
- * It might make more sense to put all the specifics in another project
- * entirely and let this one by the 'QuestManager' that allows for quests to
- * be plugged in! We create an API! And then quest implementations could come
- * as their own plugins and be drag and drop into the plugins folder. For
- * example, say I made a set of 10 quests and called them DoveQuest lol. The
- * server admin would have to pop in QuestManager, and then DoveQuest. And maybe
- * they also like this other quest pack called QuestsByTrig and dropped that
- * in too. And then the quest manager was just set to collect the quests and
- * load them up! (future work)
- * 
  * @TODO maybe split this into 'involved quests' and 'casual quests', where 'involved quests'
  * would not require any teleports out of dungeons, etc and 'involved quests' take you to
  * a special location you cannot otherwise access? If so, this should be made abstract  again

--- a/src/nmt/minecraft/QuestManager/Quest/Requirements/PossessRequirement.java
+++ b/src/nmt/minecraft/QuestManager/Quest/Requirements/PossessRequirement.java
@@ -138,7 +138,7 @@ public class PossessRequirement extends Requirement implements Listener {
 	 */
 	@Override
 	protected void update() {
-		
+		sync();
 		for (QuestPlayer player : participants.getParticipants()) {
 			if (player.getPlayer().isOnline())
 			if (player.getPlayer().getPlayer().getInventory().containsAtLeast(new ItemStack(itemType), itemCount)) {

--- a/src/nmt/minecraft/QuestManager/Quest/Requirements/SlayRequirement.java
+++ b/src/nmt/minecraft/QuestManager/Quest/Requirements/SlayRequirement.java
@@ -180,6 +180,7 @@ public class SlayRequirement extends Requirement implements Listener, Statekeepi
 				
 				if (trip)
 				{
+					progress++;
 					update();
 				}
 			}
@@ -197,8 +198,6 @@ public class SlayRequirement extends Requirement implements Listener, Statekeepi
 		if (state) {
 			return;
 		}
-		
-		progress++;
 		
 		if (progress >= count) {
 			state = true;

--- a/src/nmt/minecraft/QuestManager/Quest/Requirements/SlayRequirement.java
+++ b/src/nmt/minecraft/QuestManager/Quest/Requirements/SlayRequirement.java
@@ -1,0 +1,269 @@
+package nmt.minecraft.QuestManager.Quest.Requirements;
+
+import nmt.minecraft.QuestManager.QuestManagerPlugin;
+import nmt.minecraft.QuestManager.Configuration.State.RequirementState;
+import nmt.minecraft.QuestManager.Configuration.State.StatekeepingRequirement;
+import nmt.minecraft.QuestManager.Player.Participant;
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.Quest.Goal;
+import nmt.minecraft.QuestManager.Quest.Requirements.Factory.RequirementFactory;
+
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+/**
+ * Requires the participants to defeat (kill) some number of a type of entity.<br />
+ * This requirement is set up to work with parties.<br />
+ * This requirement also will check to make sure the name of the entities slaid matches 
+ * what is provided. If no name is provided, any entity of the same entity type
+ * will be considered valid.
+ * @author Skyler
+ * @see {@link PositionRequirement}
+ */
+public class SlayRequirement extends Requirement implements Listener, StatekeepingRequirement {
+	
+	public static class SlayFactory extends RequirementFactory<SlayRequirement> {
+
+		@Override
+		public SlayRequirement fromConfig(Goal goal, ConfigurationSection config) {
+			SlayRequirement req = new SlayRequirement(goal);
+			try {
+				req.fromConfig(config);
+			} catch (InvalidConfigurationException e) {
+				e.printStackTrace();
+			}
+			return req;
+		}
+		
+	}
+		
+	/**
+	 * The type of the entity.
+	 */
+	private EntityType type;
+	
+	/**
+	 * How many of that entity to kill before this requirement is satisfied
+	 */
+	private int count;
+	
+	/**
+	 * A custom name to be checked on dying entities
+	 */
+	private String name;
+	
+	/**
+	 * Internal variable to keep track of progress
+	 */
+	private int progress;
+	
+	/**
+	 * Super secret private constructor for factory call convenience
+	 * @param goal
+	 */
+	private SlayRequirement(Goal goal) {
+		super(goal);	
+		Bukkit.getPluginManager().registerEvents(this, QuestManagerPlugin.questManagerPlugin);
+	}
+	
+	public SlayRequirement(Goal goal, Participant participants, EntityType type, int count) {
+		this(goal, "", participants, type, null, count);
+	}
+	
+	public SlayRequirement(Goal goal, Participant participants, EntityType type, String name, int count) {
+		this(goal, "", participants, type, name, count);
+	}
+	
+	public SlayRequirement(Goal goal, String description, Participant participants, EntityType type, String name, int count) {
+		super(goal, description);
+		
+		this.participants = participants;
+		
+		this.type = type;
+		this.name = name;
+		this.count = count;
+		this.progress = 0;
+		
+	}
+
+	/**
+	 * @return the participants
+	 */
+	public Participant getParticipants() {
+		return participants;
+	}
+
+	
+	
+	/**
+	 * @return the type
+	 */
+	public EntityType getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(EntityType type) {
+		this.type = type;
+	}
+
+	/**
+	 * @return the count
+	 */
+	public int getCount() {
+		return count;
+	}
+
+	/**
+	 * @param count the count to set
+	 */
+	public void setCount(int count) {
+		this.count = count;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the progress
+	 */
+	public int getProgress() {
+		return progress;
+	}
+
+	/**
+	 * @param progress the progress to set
+	 */
+	public void setProgress(int progress) {
+		this.progress = progress;
+	}
+
+	@EventHandler
+	public void onEntityDeath(EntityDeathEvent e) {
+		
+		if (participants == null) {
+			return;
+		}
+		
+		if (e.getEntityType().equals(type)) {
+			
+			//if name is null (SHORT CIRCUIT IF SO) or if the name matches
+			if (name == null || (e.getEntity().getCustomName().equals(name)))
+			if (e.getEntity().getKiller()  != null) {
+				boolean trip = false;
+				for (QuestPlayer quester : participants.getParticipants()) {
+					if (quester.getPlayer().getUniqueId().equals(e.getEntity().getKiller().getUniqueId())) {
+						trip = true;
+						break;
+					}
+				}
+				
+				if (trip)
+				{
+					update();
+				}
+			}
+			
+		}
+		
+	}
+	
+	/**
+	 * Adds one to the kill count, and checks for completion
+	 */
+	@Override
+	public void update() {
+		
+		if (state) {
+			return;
+		}
+		
+		progress++;
+		
+		if (progress >= count) {
+			state = true;
+			updateQuest();
+			HandlerList.unregisterAll(this);
+			return;
+		}
+		
+		state = false;
+	}
+
+	@Override
+	public void fromConfig(ConfigurationSection config)
+			throws InvalidConfigurationException {
+		//  keep data about the entity type and name and count
+		//  type: "slayr"
+		//  entitytype: ENTITY_TYPE.name
+		//  forcedname: ''
+		//  count: [INT]
+			
+		if (!config.contains("type") || !config.getString("type").equals("slayr")) {
+			throw new InvalidConfigurationException();
+		}
+			
+		this.type = EntityType.valueOf(config.getString("entitytype"));
+		this.count = config.getInt("count");
+		
+		String tmp = config.getString("forcedname", "");
+		
+		if (tmp.trim().isEmpty()) {
+			this.name = null;
+		}
+		
+	}
+
+	@Override
+	public RequirementState getState() {
+		YamlConfiguration config = new YamlConfiguration();
+		
+		config.set("progress", progress);
+		
+		
+		RequirementState state = new RequirementState(config);
+		return state;
+	}
+
+	@Override
+	public void loadState(RequirementState state)
+			throws InvalidConfigurationException {
+		
+		ConfigurationSection config = state.getConfig();
+		
+		if (!config.contains("progress")) {
+			throw new InvalidConfigurationException();
+		}
+		
+		this.progress = config.getInt("progress", 0);
+		
+	}
+
+	@Override
+	public void stop() {
+		; //do nothing!		
+	}
+	
+	
+	
+}

--- a/src/nmt/minecraft/QuestManager/Quest/Requirements/SlayRequirement.java
+++ b/src/nmt/minecraft/QuestManager/Quest/Requirements/SlayRequirement.java
@@ -225,7 +225,7 @@ public class SlayRequirement extends Requirement implements Listener, Statekeepi
 		this.type = EntityType.valueOf(config.getString("entitytype"));
 		this.count = config.getInt("count");
 		
-		String tmp = config.getString("forcedname", "");
+		String tmp = config.getString("name", "");
 		
 		if (tmp.trim().isEmpty()) {
 			this.name = null;

--- a/src/nmt/minecraft/QuestManager/QuestManager.java
+++ b/src/nmt/minecraft/QuestManager/QuestManager.java
@@ -13,11 +13,17 @@ import nmt.minecraft.QuestManager.NPC.NPC;
 import nmt.minecraft.QuestManager.Quest.Quest;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.scoreboard.Scoreboard;
 
-public class QuestManager {
+public class QuestManager implements Listener {
 	
 	private List<Quest> runningQuests;
 	
@@ -265,6 +271,31 @@ public class QuestManager {
 		
 		return null;
 	}
-
+	
+	@EventHandler
+	public void onItemPickup(PlayerPickupItemEvent e) {
+		
+		if (e.isCancelled()) {
+			return;
+		}
+		
+		ItemStack item = e.getItem().getItemStack();
+		
+		if (item.getType().equals(Material.WRITTEN_BOOK)) {
+			BookMeta meta = (BookMeta) item.getItemMeta();
+			
+			if (meta.getTitle().equals("Quest Log")) {
+				e.getItem().remove();
+				e.setCancelled(true);
+				
+				QuestManagerPlugin.questManagerPlugin.getPlayerManager().getPlayer(
+						e.getPlayer().getUniqueId()).addQuestBook();
+				
+				QuestManagerPlugin.questManagerPlugin.getPlayerManager().getPlayer(
+						e.getPlayer().getUniqueId()).updateQuestBook();
+			}
+		}
+		
+	}
 	
 }

--- a/src/nmt/minecraft/QuestManager/QuestManager.java
+++ b/src/nmt/minecraft/QuestManager/QuestManager.java
@@ -177,6 +177,8 @@ public class QuestManager implements Listener {
 				
 						
 			}
+			
+			Bukkit.getPluginManager().registerEvents(this, QuestManagerPlugin.questManagerPlugin);
 
 			QuestManagerPlugin.questManagerPlugin.getLogger().info("Quest Manager finished!");	
 			

--- a/src/nmt/minecraft/QuestManager/QuestManager.java
+++ b/src/nmt/minecraft/QuestManager/QuestManager.java
@@ -18,6 +18,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -298,6 +299,16 @@ public class QuestManager implements Listener {
 			}
 		}
 		
+	}
+	
+	@EventHandler
+	public void onPlayerJoin(PlayerChangedWorldEvent e) {
+		if (QuestManagerPlugin.questManagerPlugin.getPluginConfiguration().getWorlds().contains(
+				e.getPlayer().getWorld().getName())) {
+			//if they're coming to a quest world, make sure we have a player for them
+			QuestManagerPlugin.questManagerPlugin.getPlayerManager().getPlayer(
+					e.getPlayer().getUniqueId());
+		}
 	}
 	
 }

--- a/src/nmt/minecraft/QuestManager/QuestManager.java
+++ b/src/nmt/minecraft/QuestManager/QuestManager.java
@@ -229,7 +229,9 @@ public class QuestManager implements Listener {
 		//remove starting NPCs
 		if (!questNPCs.isEmpty()) {
 			for (NPC npc : questNPCs) {
-				npc.getEntity().remove();
+				if (npc.getEntity() != null) {
+					npc.getEntity().remove();
+				}
 			}
 		}
 	}

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -10,6 +10,7 @@ import nmt.minecraft.QuestManager.Configuration.Utils.LocationState;
 import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
 import nmt.minecraft.QuestManager.Fanciful.MessagePart;
 import nmt.minecraft.QuestManager.Fanciful.TextualComponent;
+import nmt.minecraft.QuestManager.NPC.InnNPC;
 import nmt.minecraft.QuestManager.NPC.MuteNPC;
 import nmt.minecraft.QuestManager.NPC.SimpleBioptionNPC;
 import nmt.minecraft.QuestManager.NPC.SimpleChatNPC;
@@ -116,6 +117,7 @@ public class QuestManagerPlugin extends JavaPlugin {
 		SimpleChatNPC.registerWithAliases();
 		SimpleBioptionNPC.registerWithAliases();
 		SimpleQuestStartNPC.registerWithAliases();
+		InnNPC.registerWithAliases();
 		SimpleMessage.registerWithAliases();
 		BioptionMessage.registerWithAliases();
 		ConfigurationSerialization.registerClass(MessagePart.class);

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -29,8 +29,6 @@ import nmt.minecraft.QuestManager.UI.Menu.Message.BioptionMessage;
 import nmt.minecraft.QuestManager.UI.Menu.Message.SimpleMessage;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -38,8 +36,6 @@ import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -92,7 +92,7 @@ public class QuestManagerPlugin extends JavaPlugin {
 			questDirectory.mkdirs();
 		}
 		
-		
+				
 		//register our own requirements
 		reqManager.registerFactory("ARRIVE", 
 				new ArriveRequirement.ArriveFactory());

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -93,7 +93,6 @@ public class QuestManagerPlugin extends JavaPlugin {
 		if (!questDirectory.exists()) {
 			questDirectory.mkdirs();
 		}
-		
 	
 		//register our own requirements
 		reqManager.registerFactory("ARRIVE", 

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -10,6 +10,7 @@ import nmt.minecraft.QuestManager.Configuration.Utils.LocationState;
 import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
 import nmt.minecraft.QuestManager.Fanciful.MessagePart;
 import nmt.minecraft.QuestManager.Fanciful.TextualComponent;
+import nmt.minecraft.QuestManager.NPC.ForgeNPC;
 import nmt.minecraft.QuestManager.NPC.InnNPC;
 import nmt.minecraft.QuestManager.NPC.MuteNPC;
 import nmt.minecraft.QuestManager.NPC.SimpleBioptionNPC;
@@ -118,6 +119,7 @@ public class QuestManagerPlugin extends JavaPlugin {
 		SimpleBioptionNPC.registerWithAliases();
 		SimpleQuestStartNPC.registerWithAliases();
 		InnNPC.registerWithAliases();
+		ForgeNPC.registerWithAliases();
 		SimpleMessage.registerWithAliases();
 		BioptionMessage.registerWithAliases();
 		ConfigurationSerialization.registerClass(MessagePart.class);

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -16,6 +16,7 @@ import nmt.minecraft.QuestManager.NPC.MuteNPC;
 import nmt.minecraft.QuestManager.NPC.SimpleBioptionNPC;
 import nmt.minecraft.QuestManager.NPC.SimpleChatNPC;
 import nmt.minecraft.QuestManager.NPC.SimpleQuestStartNPC;
+import nmt.minecraft.QuestManager.NPC.TeleportNPC;
 import nmt.minecraft.QuestManager.Player.Party;
 import nmt.minecraft.QuestManager.Player.QuestPlayer;
 import nmt.minecraft.QuestManager.Quest.Requirements.ArriveRequirement;
@@ -120,6 +121,7 @@ public class QuestManagerPlugin extends JavaPlugin {
 		SimpleQuestStartNPC.registerWithAliases();
 		InnNPC.registerWithAliases();
 		ForgeNPC.registerWithAliases();
+		TeleportNPC.registerWithAliases();
 		SimpleMessage.registerWithAliases();
 		BioptionMessage.registerWithAliases();
 		ConfigurationSerialization.registerClass(MessagePart.class);

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -29,6 +29,8 @@ import nmt.minecraft.QuestManager.UI.Menu.Message.BioptionMessage;
 import nmt.minecraft.QuestManager.UI.Menu.Message.SimpleMessage;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -36,6 +38,8 @@ import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -94,7 +98,7 @@ public class QuestManagerPlugin extends JavaPlugin {
 			questDirectory.mkdirs();
 		}
 		
-				
+	
 		//register our own requirements
 		reqManager.registerFactory("ARRIVE", 
 				new ArriveRequirement.ArriveFactory());

--- a/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
+++ b/src/nmt/minecraft/QuestManager/QuestManagerPlugin.java
@@ -19,6 +19,7 @@ import nmt.minecraft.QuestManager.Player.QuestPlayer;
 import nmt.minecraft.QuestManager.Quest.Requirements.ArriveRequirement;
 import nmt.minecraft.QuestManager.Quest.Requirements.PositionRequirement;
 import nmt.minecraft.QuestManager.Quest.Requirements.PossessRequirement;
+import nmt.minecraft.QuestManager.Quest.Requirements.SlayRequirement;
 import nmt.minecraft.QuestManager.Quest.Requirements.VanquishRequirement;
 import nmt.minecraft.QuestManager.UI.ChatGuiHandler;
 import nmt.minecraft.QuestManager.UI.Menu.Message.BioptionMessage;
@@ -100,6 +101,8 @@ public class QuestManagerPlugin extends JavaPlugin {
 				new PossessRequirement.PossessFactory());
 		reqManager.registerFactory("VANQUISH", 
 				new VanquishRequirement.VanquishFactory());
+		reqManager.registerFactory("SLAY", 
+				new SlayRequirement.SlayFactory());
 		
 	}
 	

--- a/src/nmt/minecraft/QuestManager/Scheduling/DispersedScheduler.java
+++ b/src/nmt/minecraft/QuestManager/Scheduling/DispersedScheduler.java
@@ -1,0 +1,155 @@
+package nmt.minecraft.QuestManager.Scheduling;
+
+import java.util.List;
+import java.util.ListIterator;
+
+import nmt.minecraft.QuestManager.QuestManagerPlugin;
+
+import org.bukkit.Bukkit;
+
+/**
+ * Gathers a list of scheduled Tickable entities and goes through ticking each
+ * after the others. Each registered Tickable entity causes a measured wait
+ * before the next creature is ticked, causing a spread out tick chain.
+ * @author Skyler
+ *
+ */
+public class DispersedScheduler extends Scheduler {
+
+	/**
+	 * List of Tickable entities, used when iterating
+	 */
+	private List<Tickable> list;
+
+	/**
+	 * Iterator to keep track of where we are in our changing list
+	 */
+	private ListIterator<Tickable> iterator;
+	
+	/**
+	 * The delay between two consequtive ticks, in minecraft ticks
+	 */
+	private long delay;
+	
+	/**
+	 * How long to wait after finishing a tick run before starting another
+	 */
+	private long rest;
+	
+	/**
+	 * Keeps track of whether the scheduler is currently in rest mode
+	 */
+	private boolean resting;
+	
+	/**
+	 * How long to delay between ticks by default
+	 */
+	private static long defaultDelay = 40;
+	
+	private static long defaultRest = 200;
+	
+	private static DispersedScheduler scheduler = null;
+	
+	/**
+	 * Return the current instanced DispersedScheduler.<br />
+	 * If a scheduler has yet to be created, it will be created with default values
+	 * from this call.
+	 * @return
+	 */
+	public static DispersedScheduler getScheduler() {
+		if (scheduler == null) {
+			scheduler = new DispersedScheduler();
+		}
+	
+		return scheduler;
+	}
+	
+	private DispersedScheduler() {
+		this.delay = defaultDelay;
+		this.rest = defaultRest;
+		
+		resting = true;
+		Bukkit.getScheduler().runTaskLater(QuestManagerPlugin.questManagerPlugin
+				, this, rest);
+	}
+	
+	/**
+	 * @return the delay
+	 */
+	public long getDelay() {
+		return delay;
+	}
+
+	/**
+	 * @param delay the delay to set
+	 */
+	public void setDelay(long delay) {
+		this.delay = delay;
+	}
+
+	/**
+	 * @return the rest
+	 */
+	public long getRest() {
+		return rest;
+	}
+
+	/**
+	 * @param rest the rest to set
+	 */
+	public void setRest(long rest) {
+		this.rest = rest;
+	}
+
+	/**
+	 * @return the list
+	 */
+	public List<Tickable> getRegisteredList() {
+		return list;
+	}
+
+	@Override
+	public void run() {
+		//depends on whether we are resting or not
+		//resting means we need to start the list
+		//not resting means we need to keep stepping through the list
+		if (resting) {
+			//was resting, start list
+			
+			if (list == null || list.isEmpty()) {
+				resting = true;
+				Bukkit.getScheduler().runTaskLater(QuestManagerPlugin.questManagerPlugin
+						, this, rest);
+				return;
+			}
+			
+			resting = false;
+			iterator = list.listIterator();
+			
+			iterator.next().tick();
+			Bukkit.getScheduler().runTaskLater(QuestManagerPlugin.questManagerPlugin
+					, this, delay);
+			
+		} else {
+			//already going through list. Keep going, or start rest
+			if (!iterator.hasNext()) {
+				//finished list
+				resting = true;
+				Bukkit.getScheduler().runTaskLater(QuestManagerPlugin.questManagerPlugin
+						, this, rest);
+			} else {
+				//still more in the list to go
+				iterator.next().tick();
+				Bukkit.getScheduler().runTaskLater(QuestManagerPlugin.questManagerPlugin
+						, this, delay);
+			}
+		}
+	}
+
+	@Override
+	public void register(Tickable tick) {
+		this.list.add(tick);
+	}
+
+	
+}

--- a/src/nmt/minecraft/QuestManager/Scheduling/DispersedScheduler.java
+++ b/src/nmt/minecraft/QuestManager/Scheduling/DispersedScheduler.java
@@ -1,5 +1,6 @@
 package nmt.minecraft.QuestManager.Scheduling;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -67,6 +68,8 @@ public class DispersedScheduler extends Scheduler {
 	private DispersedScheduler() {
 		this.delay = defaultDelay;
 		this.rest = defaultRest;
+		
+		this.list = new LinkedList<Tickable>();
 		
 		resting = true;
 		Bukkit.getScheduler().runTaskLater(QuestManagerPlugin.questManagerPlugin

--- a/src/nmt/minecraft/QuestManager/Scheduling/Scheduler.java
+++ b/src/nmt/minecraft/QuestManager/Scheduling/Scheduler.java
@@ -1,0 +1,16 @@
+package nmt.minecraft.QuestManager.Scheduling;
+
+
+/**
+ * Keeps track of registered entities and delivers ticks in a regular fashion
+ * @author Skyler
+ *
+ */
+public abstract class Scheduler implements Runnable {
+	
+	/**
+	 * Register a Tickable entity to be ticked 
+	 * @param tick
+	 */
+	public abstract void register(Tickable tick);
+}

--- a/src/nmt/minecraft/QuestManager/Scheduling/Tickable.java
+++ b/src/nmt/minecraft/QuestManager/Scheduling/Tickable.java
@@ -1,0 +1,21 @@
+package nmt.minecraft.QuestManager.Scheduling;
+
+/**
+ * An object is Tickable if they can be ticked.<br />
+ * All tickable objects can register with a scheduler and then be visited by
+ * ticks.<br />
+ * <p>
+ * Some easy applications of ticks are movement patterns, regular regeneration, etc
+ * @author Skyler
+ *
+ */
+public interface Tickable {
+	
+	/**
+	 * Performs a scheduled 'tick'.<br />
+	 * This method can mean anything a Tickable class wants it to be. Scheduled
+	 * Tickable classes receive calls to this on a scheduled and regular basis
+	 */
+	public void tick();
+	
+}

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
@@ -3,7 +3,6 @@ package nmt.minecraft.QuestManager.UI.Menu.Action;
 
 import java.util.ListIterator;
 
-import net.minecraft.server.v1_8_R3.Material;
 import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
 import nmt.minecraft.QuestManager.Player.QuestPlayer;
 import nmt.minecraft.QuestManager.UI.ChatMenu;
@@ -11,6 +10,7 @@ import nmt.minecraft.QuestManager.UI.Menu.SimpleChatMenu;
 import nmt.minecraft.QuestManager.UI.Menu.Message.Message;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
@@ -25,6 +25,31 @@ import de.inventivegames.util.title.TitleManager;
  *
  */
 public class ForgeAction implements MenuAction {
+	
+	private enum Repairable {
+		SWORD,
+		BOW,
+		PICKAXE,
+		SPADE,
+		AXE,
+		CHESTPLATE,
+		LEGGINGS,
+		HELMET,
+		BOOTS;
+		
+		public static boolean isRepairable(Material mat) {
+			
+			String cname = mat.name();
+			for (Repairable rep : Repairable.values()) {
+				if (cname.endsWith(rep.name())) {
+					return true;
+				}
+			}
+			
+			
+			return false;
+		}
+	}
 
 	private int cost;
 	
@@ -71,6 +96,7 @@ public class ForgeAction implements MenuAction {
 					continue;
 				}
 				if (!item.getType().equals(Material.AIR))
+				if (Repairable.isRepairable(item.getType()))
 				if (item.getDurability() > 0) {
 					item.setDurability((short) 0);
 					count++;

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
@@ -1,0 +1,113 @@
+package nmt.minecraft.QuestManager.UI.Menu.Action;
+
+
+import java.util.ListIterator;
+
+import net.minecraft.server.v1_8_R3.Material;
+import nmt.minecraft.QuestManager.Fanciful.FancyMessage;
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.UI.ChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.SimpleChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.Message.Message;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import de.inventivegames.util.tellraw.TellrawConverterLite;
+import de.inventivegames.util.title.TitleManager;
+
+/**
+ * Repairs a player's equipment
+ * @author Skyler
+ *
+ */
+public class ForgeAction implements MenuAction {
+
+	private int cost;
+	
+	private QuestPlayer player;
+	
+	private Message denial;
+	
+	public ForgeAction(int cost, QuestPlayer player, Message denialMessage) {
+		this.cost = cost;
+		this.player = player;
+		this.denial = denialMessage;
+	}
+	
+	@Override
+	public void onAction() {
+		
+		//check their money
+		if (player.getMoney() >= cost) {
+			//they have enough money
+			
+			//play smith sound, take money,
+			//search inventory and find all equipment (:S) and repair it
+			//and display a title
+			
+			
+			if (!player.getPlayer().isOnline()) {
+				System.out.println("Very bad ForgeAction error!!!!!!!!!!!!!");
+				return;
+			}
+			
+			
+			
+			Player p = player.getPlayer().getPlayer();
+			
+			Inventory inv = p.getInventory();
+			ListIterator<ItemStack> items = inv.iterator();
+			
+			ItemStack item;
+			int count = 0;
+			
+			while (items.hasNext()) {
+				item = items.next();
+				if (item == null) {
+					continue;
+				}
+				if (!item.getType().equals(Material.AIR))
+				if (item.getDurability() < item.getType().getMaxDurability()-1) {
+					item.setDurability((short) (item.getType().getMaxDurability()-1));
+					count++;
+				}
+			}
+			
+			//make sure they had items to repair
+			if (count == 0) {
+				//no items were repaired!
+				ChatMenu whoops = new SimpleChatMenu(
+						new FancyMessage("Actually, you don't seem to have any equipment"
+								+ " in need of repair!"));
+				whoops.show(p);
+				return;
+			}
+			
+			player.addMoney(-cost);
+			
+			p.playSound(p.getLocation(), Sound.ANVIL_USE, 1, 0);
+			
+			TitleManager.sendTimings(p, 20, 40, 20);
+			
+			TitleManager.sendSubTitle(p, TellrawConverterLite.convertToJSON(
+					ChatColor.BLUE + "" + count + " item(s) have been repaired"));
+
+	        TitleManager.sendTitle(p, TellrawConverterLite.convertToJSON(
+	        		ChatColor.GREEN + "Forge"));
+			
+		} else {
+			//not enough money
+			//show them a menu, sorrow
+						
+			ChatMenu menu = new SimpleChatMenu(denial.getFormattedMessage());
+			
+			menu.show(player.getPlayer().getPlayer());
+		}
+		
+	}
+
+}

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
@@ -71,8 +71,8 @@ public class ForgeAction implements MenuAction {
 					continue;
 				}
 				if (!item.getType().equals(Material.AIR))
-				if (item.getDurability() < item.getType().getMaxDurability()-1) {
-					item.setDurability((short) (item.getType().getMaxDurability()-1));
+				if (item.getDurability() > 0) {
+					item.setDurability((short) 0);
 					count++;
 				}
 			}

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/ForgeAction.java
@@ -103,6 +103,19 @@ public class ForgeAction implements MenuAction {
 				}
 			}
 			
+			//also run check over their equipment
+			for (ItemStack it : p.getEquipment().getArmorContents()) {
+				if (it == null) {
+					continue;
+				}
+				if (!it.getType().equals(Material.AIR))
+				if (Repairable.isRepairable(it.getType()))
+				if (it.getDurability() > 0) {
+					it.setDurability((short) 0);
+					count++;
+				}
+			}
+			
 			//make sure they had items to repair
 			if (count == 0) {
 				//no items were repaired!

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/InnAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/InnAction.java
@@ -1,0 +1,89 @@
+package nmt.minecraft.QuestManager.UI.Menu.Action;
+
+
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.UI.ChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.SimpleChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.Message.Message;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import de.inventivegames.util.tellraw.TellrawConverterLite;
+import de.inventivegames.util.title.TitleManager;
+
+/**
+ * Rests a player, restoring health and hunger
+ * @author Skyler
+ *
+ */
+public class InnAction implements MenuAction {
+
+	private int cost;
+	
+	private QuestPlayer player;
+	
+	private Message denial;
+	
+	public InnAction(int cost, QuestPlayer player, Message denialMessage) {
+		this.cost = cost;
+		this.player = player;
+		this.denial = denialMessage;
+	}
+	
+	@Override
+	public void onAction() {
+		
+		//check their money
+		if (player.getMoney() >= cost) {
+			//they have enough money
+			
+			//blindness for 3 seconds, title saying you're now rested?
+			//don't forget to restore health, hunger
+			//and take out some money
+			
+			if (!player.getPlayer().isOnline()) {
+				System.out.println("Very bad InnAction error!!!!!!!!!!!!!");
+				return;
+			}
+			
+			player.addMoney(-cost);
+			
+			Player p = player.getPlayer().getPlayer();
+			p.setHealth(p.getMaxHealth());
+			p.setFoodLevel(20);
+			p.setExhaustion(0f);
+			p.setSaturation(20f);
+			
+			p.addPotionEffect(
+					new PotionEffect(PotionEffectType.BLINDNESS, 60, 1));
+			
+			TitleManager.sendTimings(p, 20, 40, 20);
+			
+			TitleManager.sendSubTitle(p, TellrawConverterLite.convertToJSON(
+	        		ChatColor.GREEN + "You rest at the inn"));
+
+	        TitleManager.sendTitle(p, TellrawConverterLite.convertToJSON(
+	        		ChatColor.BLUE + "Your health and hunger are restored"));
+			
+		} else {
+			//not enough money
+			//show them a menu, sorrow
+			
+//			FancyMessage msg = new FancyMessage("I'm sorry, but you ")
+//				.then("don't seem to have enough money...")
+//				.color(ChatColor.DARK_RED);
+//			
+//			SimpleMessage message = new SimpleMessage(msg);
+//			message.setSourceLabel(new FancyMessage());
+			
+			ChatMenu menu = new SimpleChatMenu(denial.getFormattedMessage());
+			
+			menu.show(player.getPlayer().getPlayer());
+		}
+		
+	}
+
+}

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/InnAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/InnAction.java
@@ -71,14 +71,7 @@ public class InnAction implements MenuAction {
 		} else {
 			//not enough money
 			//show them a menu, sorrow
-			
-//			FancyMessage msg = new FancyMessage("I'm sorry, but you ")
-//				.then("don't seem to have enough money...")
-//				.color(ChatColor.DARK_RED);
-//			
-//			SimpleMessage message = new SimpleMessage(msg);
-//			message.setSourceLabel(new FancyMessage());
-			
+						
 			ChatMenu menu = new SimpleChatMenu(denial.getFormattedMessage());
 			
 			menu.show(player.getPlayer().getPlayer());

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/InnAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/InnAction.java
@@ -7,6 +7,7 @@ import nmt.minecraft.QuestManager.UI.Menu.SimpleChatMenu;
 import nmt.minecraft.QuestManager.UI.Menu.Message.Message;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -58,15 +59,17 @@ public class InnAction implements MenuAction {
 			p.setSaturation(20f);
 			
 			p.addPotionEffect(
-					new PotionEffect(PotionEffectType.BLINDNESS, 60, 1));
+					new PotionEffect(PotionEffectType.BLINDNESS, 60, 5));
 			
 			TitleManager.sendTimings(p, 20, 40, 20);
 			
 			TitleManager.sendSubTitle(p, TellrawConverterLite.convertToJSON(
-	        		ChatColor.GREEN + "You rest at the inn"));
+					ChatColor.BLUE + "Your health and hunger are restored"));
 
 	        TitleManager.sendTitle(p, TellrawConverterLite.convertToJSON(
-	        		ChatColor.BLUE + "Your health and hunger are restored"));
+	        		ChatColor.GREEN + "Sweet Dreams"));
+	        
+	        p.playSound(p.getLocation(), Sound.LEVEL_UP, 1, .5f);
 			
 		} else {
 			//not enough money

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Action/TeleportAction.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Action/TeleportAction.java
@@ -1,0 +1,73 @@
+package nmt.minecraft.QuestManager.UI.Menu.Action;
+
+
+import nmt.minecraft.QuestManager.Player.QuestPlayer;
+import nmt.minecraft.QuestManager.UI.ChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.SimpleChatMenu;
+import nmt.minecraft.QuestManager.UI.Menu.Message.Message;
+
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Ferries a player
+ * @author Skyler
+ *
+ */
+public class TeleportAction implements MenuAction {
+
+	private int cost;
+	
+	private Location destination;
+	
+	private QuestPlayer player;
+	
+	private Message denial;
+	
+	public TeleportAction(int cost, Location destination, QuestPlayer player, Message denialMessage) {
+		this.cost = cost;
+		this.player = player;
+		this.denial = denialMessage;
+		this.destination = destination;
+	}
+	
+	@Override
+	public void onAction() {
+		
+		//check their money
+		if (player.getMoney() >= cost) {
+			//they have enough money
+			
+			//blindness for some time, but just teleportation & particles!
+			
+			if (!player.getPlayer().isOnline()) {
+				System.out.println("Very bad TeleportAction error!!!!!!!!!!!!!");
+				return;
+			}
+			
+			player.addMoney(-cost);
+			
+			Player p = player.getPlayer().getPlayer();
+			
+			p.addPotionEffect(
+					new PotionEffect(PotionEffectType.BLINDNESS, 60, 5));
+			
+			p.teleport(destination);
+			destination.getWorld().playEffect(destination, Effect.STEP_SOUND, 0);
+			
+			
+		} else {
+			//not enough money
+			//show them a menu, sorrow
+						
+			ChatMenu menu = new SimpleChatMenu(denial.getFormattedMessage());
+			
+			menu.show(player.getPlayer().getPlayer());
+		}
+		
+	}
+
+}

--- a/src/nmt/minecraft/QuestManager/UI/Menu/BioptionChatMenu.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/BioptionChatMenu.java
@@ -43,24 +43,27 @@ public class BioptionChatMenu extends ChatMenu implements RespondableMenu {
 		//two things to do. 
 		if (arg.equals(BioptionMessage.OPTION1)) {
 			
-			if (opt1 != null) {
-				opt1.onAction();
-			}
 			
 			if (messageCache.getResponse1() != null) {
 				SimpleChatMenu menu = new SimpleChatMenu(messageCache.getResponse1());
 				menu.show(player);
 			}
+
+			if (opt1 != null) {
+				opt1.onAction();
+			}
 			
 			return true;
 		} else if (arg.equals(BioptionMessage.OPTION2)) {
-			if (opt2 != null) {
-				opt2.onAction();
-			}
+			
 			
 			if (messageCache.getResponse2() != null) {
 				SimpleChatMenu menu = new SimpleChatMenu(messageCache.getResponse2());
 				menu.show(player);
+			}
+			
+			if (opt2 != null) {
+				opt2.onAction();
 			}
 			
 			return true;

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Message/SimpleMessage.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Message/SimpleMessage.java
@@ -99,7 +99,7 @@ public class SimpleMessage extends Message {
 
 	@Override
 	public FancyMessage getFormattedMessage() {
-		return new FancyMessage("\n")
+		return new FancyMessage("")
 		.then(label == null ? 
 				new FancyMessage("Unknown")	: label)
 			.color(ChatColor.DARK_GRAY)

--- a/src/nmt/minecraft/QuestManager/UI/Menu/Message/SimpleMessage.java
+++ b/src/nmt/minecraft/QuestManager/UI/Menu/Message/SimpleMessage.java
@@ -99,7 +99,7 @@ public class SimpleMessage extends Message {
 
 	@Override
 	public FancyMessage getFormattedMessage() {
-		return new FancyMessage("")
+		return new FancyMessage("\n")
 		.then(label == null ? 
 				new FancyMessage("Unknown")	: label)
 			.color(ChatColor.DARK_GRAY)

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,7 +1,8 @@
 name: QuestManager
 main: nmt.minecraft.QuestManager.QuestManagerPlugin
 version: 1.0
-softdepend: [Fanciful]
+softdepend: [Fanciful, Multiverse-Core]
+loadfirst:
 commands:
     questlog:
         usage: /questlog

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,9 @@ Needed
 
 ### For Launch
 
-+ Increased requirements, like 'slay 10 rabbits' or 'talk to' or 'deliver'
++ Increased requirements:
+++ 'talk to'
+++ 'deliver'
 
 ### For a complete QM
 
@@ -25,7 +27,5 @@ Extra Features
 + API capability (program your own very customized quests by getting API access
   to QM)
 + Visual information, like hovering text over monsters or party members, etc
-+ A nice visual way of interacting with quest components, like clicking
-  responses in the chat bar instead of typing in commands
 + Add a graphical editor for quest configuration files
 


### PR DESCRIPTION
Createa different NPCs for different things (inn and forge and teleport npcs) and use experience as levels. 
Updated the way quests update to no longer be silent without a quest book, and fixed a bunch of bugs with them
Added repeatable quests and quests with prereqs, and track entrance to a QM world for nicer experience.
